### PR TITLE
AP_Proximity: fix get_upward/downward_distance logic

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -146,6 +146,9 @@ public:
     friend class AP_AdvancedFailsafe_Copter;
 #endif
     friend class AP_Arming_Copter;
+#if AC_AVOID_ENABLED == ENABLED
+    friend class AC_PosControl; // position control needs to access a AC_Avoid function
+#endif
 
     Copter(void);
 

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -15,18 +15,22 @@ void Copter::fence_check()
     fence.set_home_distance(home_distance*0.01f);
 
     // check for a breach
-
-    new_breaches = fence.check_fence(rangefinder.distance_cm_orient(ROTATION_PITCH_270)/100.0f);
+    // use baro if out of range
+    if ((current_loc.alt/100.0f) > (rangefinder.max_distance_cm_orient(ROTATION_PITCH_270)/100.0f)) {
+        new_breaches = fence.check_fence(current_loc.alt/100.0f);
+    } else {
+        new_breaches = fence.check_fence(rangefinder.distance_cm_orient(ROTATION_PITCH_270)/100.0f);
+    }
     // return immediately if motors are not armed
-    if(!motors->armed()) {
+    if (!motors->armed()) {
         return;
     }
 
     // if there is a new breach take action
-    if( new_breaches != AC_FENCE_TYPE_NONE ) {
+    if ( new_breaches != AC_FENCE_TYPE_NONE ) {
 
         // if the user wants some kind of response and motors are armed
-        if(fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY ) {
+        if (fence.get_action() != AC_FENCE_ACTION_REPORT_ONLY ) {
 
             // disarm immediately if we think we are on the ground or in a manual flight mode with zero throttle
             // don't disarm if the high-altitude fence has been broken because it's likely the user has pulled their throttle to zero to bring it down

--- a/ArduCopter/fence.cpp
+++ b/ArduCopter/fence.cpp
@@ -15,8 +15,8 @@ void Copter::fence_check()
     fence.set_home_distance(home_distance*0.01f);
 
     // check for a breach
-    new_breaches = fence.check_fence(current_loc.alt/100.0f);
 
+    new_breaches = fence.check_fence(rangefinder.distance_cm_orient(ROTATION_PITCH_270)/100.0f);
     // return immediately if motors are not armed
     if(!motors->armed()) {
         return;

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -150,6 +150,16 @@ failed:
         // this flight mode change could be automatic (i.e. fence, battery, GPS or GCS failsafe)
         // but it should be harmless to disable the fence temporarily in these situations as well
         fence.manual_recovery_start();
+        // disable low altitude fence when landing
+        switch (mode) {
+            case LAND:
+                FALLTHROUGH;
+            case RTL:
+                fence.enable_low_alt(false);
+                break;
+            default:
+                break;
+        }
 #endif
         
 #if FRSKY_TELEM_ENABLED == ENABLED
@@ -271,6 +281,13 @@ void Copter::update_flight_mode()
         default:
             break;
     }
+#if AC_FENCE == ENABLED
+    if (   (control_mode != LAND)
+        && (control_mode != RTL)
+        && (100.0f *baro_alt > fence.get_safe_alt_min())) {
+       fence.enable_low_alt(true); // Potentially enable low altitude fence the first time the vehicle is above it
+    }
+#endif
 }
 
 // exit_mode - high level call to organise cleanup as a flight mode is exited

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -282,10 +282,10 @@ void Copter::update_flight_mode()
             break;
     }
 #if AC_FENCE == ENABLED
-    if (   (control_mode != LAND)
-        && (control_mode != RTL)
-        && (100.0f *baro_alt > fence.get_safe_alt_min())) {
-       fence.enable_low_alt(true); // Potentially enable low altitude fence the first time the vehicle is above it
+    if (!fence._low_alt_fence_enabled && (control_mode != LAND) && (control_mode != RTL)) {
+        if ((current_loc.alt/100.0f) > fence.get_safe_alt_min() && (rangefinder.has_orientation(ROTATION_PITCH_270) ? (rangefinder.distance_cm_orient(ROTATION_PITCH_270)/100.0f > fence.get_safe_alt_min()) : true)) {
+            fence.enable_low_alt(true); // Potentially enable low altitude fence the first time the vehicle is above it
+        }
     }
 #endif
 }

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1,6 +1,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include "AC_PosControl.h"
 #include <AP_Math/AP_Math.h>
+#include "../ArduCopter/Copter.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -384,8 +385,14 @@ void AC_PosControl::pos_to_rate_z()
     // To-Do: check these speed limits here or in the pos->rate controller
     _limit.vel_up = false;
     _limit.vel_down = false;
-    if (_vel_target.z < _speed_down_cms) {
-        _vel_target.z = _speed_down_cms;
+
+    // adjust z-acceleration based on fence FORCE FIELD
+    float target_descend_rate = _speed_down_cms;
+
+    copter.avoid.adjust_velocity_z(_p_pos_z.kP(), _vel_target.z, target_descend_rate);
+
+    if (_vel_target.z < target_descend_rate) {
+        _vel_target.z = target_descend_rate;
         _limit.vel_down = true;
     }
     if (_vel_target.z > _speed_up_cms) {

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -98,7 +98,14 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
     float alt_min_diff_cm = 0.0f;
 
     if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
-        float veh_alt = get_alt_above_home();
+        float veh_alt;
+        if (_proximity.get_downward_distance(veh_alt))
+        {
+            veh_alt = veh_alt *100.0f;
+        }else{
+            veh_alt = get_alt_above_home();
+        }
+
 
         // calculate distance below fence
         if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) > 0) {

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -1,5 +1,14 @@
 #include "AC_Avoid.h"
 
+#define AC_AVOID_DEBUG 1
+
+#if AC_AVOID_DEBUG
+  #include <GCS_MAVLINK/GCS.h>
+  #define Debug(level, fmt, args ...)  do { if (level <= AC_AVOID_DEBUG) { GCS_MAVLINK::send_text(MAV_SEVERITY_INFO, fmt, ## args); } } while (0)
+#else
+  #define Debug(level, fmt, args ...)
+#endif
+
 const AP_Param::GroupInfo AC_Avoid::var_info[] = {
 
     // @Param: ENABLE
@@ -89,6 +98,12 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         return;
     }
 
+    {
+        float proximity_alt_diff_m;
+        _proximity.get_downward_distance(proximity_alt_diff_m);
+        Debug(1, "RAW_PRX %f", proximity_alt_diff_m);
+    }
+    Debug(1, "Entered: climb_rate_cms %f accel_cmss %f", climb_rate_cms, accel_cmss);
     // limit acceleration
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
@@ -175,6 +190,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         // limit descend rate
         const float max_speed = get_max_speed(kP, accel_cmss_limited, alt_min_diff_cm);
         climb_rate_cms = MAX(-max_speed, climb_rate_cms);
+        Debug(1, "ADJUSTED: climb_rate_cms %f  max_speed %f", climb_rate_cms, max_speed);
     }
 }
 

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -89,23 +89,30 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         return;
     }
 
-    // do not adjust climb_rate if level or descending
-    if (climb_rate_cms <= 0.0f) {
-        return;
-    }
-
     // limit acceleration
     float accel_cmss_limited = MIN(accel_cmss, AC_AVOID_ACCEL_CMSS_MAX);
 
     bool limit_alt = false;
+    bool limit_min_alt = false;
     float alt_diff_cm = 0.0f;   // distance from altitude limit to vehicle in cm (positive means vehicle is below limit)
+    float alt_min_diff_cm = 0.0f;
 
-    // calculate distance below fence
-    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0 && (_fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) > 0) {
-        // calculate distance from vehicle to safe altitude
+    if ((_enabled & AC_AVOID_STOP_AT_FENCE) > 0) {
         float veh_alt = get_alt_above_home();
-        alt_diff_cm = _fence.get_safe_alt_max() * 100.0f - veh_alt;
-        limit_alt = true;
+
+        // calculate distance below fence
+        if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) > 0) {
+          // calculate distance from vehicle to safe ceiling altitude
+          alt_diff_cm = _fence.get_safe_alt_max() * 100.0f - veh_alt;
+          limit_alt = true;
+        }
+
+        // calculate distance above fence
+        if ((_fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MIN) > 0) {
+           // calculate distance from vehicle to safe floor altitude
+           alt_min_diff_cm = veh_alt - _fence.get_safe_alt_min() * 100.0f;
+           limit_min_alt = true;
+        }
     }
 
     // calculate distance to optical flow altitude limit
@@ -120,6 +127,7 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
 
     // get distance from proximity sensor (in meters, convert to cm)
     float proximity_alt_diff_m;
+    // case upward rangefinder
     if (_proximity.get_upward_distance(proximity_alt_diff_m)) {
         float proximity_alt_diff_cm = (proximity_alt_diff_m - _margin) * 100.0f;
         if (!limit_alt || proximity_alt_diff_cm < alt_diff_cm) {
@@ -127,10 +135,18 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         }
         limit_alt = true;
     }
+    // case downward rangefinder
+    if (_proximity.get_downward_distance(proximity_alt_diff_m)) {
+        float proximity_alt_diff_cm = (proximity_alt_diff_m - _margin) * 100.0f;
+        if (!limit_alt || proximity_alt_diff_cm < alt_min_diff_cm) {
+            alt_min_diff_cm = proximity_alt_diff_cm;
+        }
+        limit_min_alt = true;
+        }
 
     // limit climb rate
-    if (limit_alt) {
-        // do not allow climbing if we've breached the safe altitude
+    if (limit_alt && climb_rate_cms > 0.0f) {
+        // do not allow climbing if we've breached the safe ceiling altitude
         if (alt_diff_cm <= 0.0f) {
             climb_rate_cms = MIN(climb_rate_cms, 0.0f);
             return;
@@ -139,6 +155,19 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
         // limit climb rate
         const float max_speed = get_max_speed(kP, accel_cmss_limited, alt_diff_cm);
         climb_rate_cms = MIN(max_speed, climb_rate_cms);
+    }
+
+    // limit descend rate
+    if (limit_min_alt && climb_rate_cms < 0.0f) {
+        // do not allow descending if we've breached the safe floor altitude
+        if (alt_min_diff_cm <= 0.0f) {
+            climb_rate_cms = MAX(climb_rate_cms, 0.0f);
+            return;
+        }
+
+        // limit descend rate
+        const float max_speed = get_max_speed(kP, accel_cmss_limited, alt_min_diff_cm);
+        climb_rate_cms = MAX(-max_speed, climb_rate_cms);
     }
 }
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -35,7 +35,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Range: 10 1000
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO("ALT_MAX",     3,  AC_Fence,   _alt_max,       AC_FENCE_ALT_MAX_DEFAULT),
+    AP_GROUPINFO_FRAME("ALT_MAX",     3,  AC_Fence,   _alt_max,       AC_FENCE_ALT_MAX_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_PLANE | AP_PARAM_FRAME_SUB | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI),
 
     // @Param: RADIUS
     // @DisplayName: Circular Fence Radius
@@ -67,7 +67,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Range: -100 100
     // @Increment: 1
     // @User: Standard
-    AP_GROUPINFO_FRAME("ALT_MIN",     7,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT, AP_PARAM_FRAME_SUB),
+    AP_GROUPINFO_FRAME("ALT_MIN",     7,  AC_Fence,   _alt_min,       AC_FENCE_ALT_MIN_DEFAULT, AP_PARAM_FRAME_COPTER | AP_PARAM_FRAME_PLANE | AP_PARAM_FRAME_SUB | AP_PARAM_FRAME_TRICOPTER | AP_PARAM_FRAME_HELI),
 
     AP_GROUPEND
 };

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -15,6 +15,7 @@
 #define AC_FENCE_TYPE_ALT_MAX                       1       // high alt fence which usually initiates an RTL
 #define AC_FENCE_TYPE_CIRCLE                        2       // circular horizontal fence (usually initiates an RTL)
 #define AC_FENCE_TYPE_POLYGON                       4       // polygon horizontal fence
+#define AC_FENCE_TYPE_ALT_MIN                       8       // min alt fence
 
 // valid actions should a fence be breached
 #define AC_FENCE_ACTION_REPORT_ONLY                 0       // report to GCS that boundary has been breached but take no further action
@@ -25,6 +26,7 @@
 #define AC_FENCE_ALT_MIN_DEFAULT                    -10.0f  // default maximum depth in meters
 #define AC_FENCE_CIRCLE_RADIUS_DEFAULT              300.0f  // default circular fence radius is 300m
 #define AC_FENCE_ALT_MAX_BACKUP_DISTANCE            20.0f   // after fence is broken we recreate the fence 20m further up
+#define AC_FENCE_ALT_MIN_BACKUP_DISTANCE            1.0f    // after fence is broken we recreate the fence 1m further down
 #define AC_FENCE_CIRCLE_RADIUS_BACKUP_DISTANCE      20.0f   // after fence is broken we recreate the fence 20m further out
 #define AC_FENCE_MARGIN_DEFAULT                     2.0f    // default distance in meters that autopilot's should maintain from the fence to avoid a breach
 
@@ -150,10 +152,12 @@ private:
 
     // backup fences
     float           _alt_max_backup;        // backup altitude upper limit in meters used to refire the breach if the vehicle continues to move further away
+    float           _alt_min_backup;        // backup altitude lower limit in meters used to refire the breach if the vehicle continues to move further away
     float           _circle_radius_backup;  // backup circle fence radius in meters used to refire the breach if the vehicle continues to move further away
 
     // breach distances
     float           _alt_max_breach_distance;   // distance above the altitude max
+    float           _alt_min_breach_distance;   // distance below the altitude min
     float           _circle_breach_distance;    // distance beyond the circular fence
 
     // other internal variables

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -126,6 +126,7 @@ public:
     void handle_msg(GCS_MAVLINK &link, mavlink_message_t* msg);
 
     static const struct AP_Param::GroupInfo var_info[];
+    bool            _low_alt_fence_enabled;
 
 private:
     AC_Fence(const AP_AHRS &ahrs, const AP_InertialNav &inav);
@@ -180,6 +181,6 @@ private:
     bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
     bool            _boundary_loaded = false;       // true if boundary array has been loaded from eeprom
     bool            _boundary_valid = false;        // true if boundary forms a closed polygon
-    bool            _low_alt_fence_enabled;
+
 
 };

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -56,6 +56,9 @@ public:
     /// get_enabled_fences - returns bitmask of enabled fences
     uint8_t get_enabled_fences() const;
 
+    // the vehicle code should use this to disable low altitude fence
+    void enable_low_alt(bool value);
+
     /// pre_arm_check - returns true if all pre-takeoff checks have completed successfully
     bool pre_arm_check(const char* &fail_msg) const;
 
@@ -88,7 +91,7 @@ public:
     /// get_safe_alt - returns maximum safe altitude (i.e. alt_max - margin)
     float get_safe_alt_max() const { return _alt_max - _margin; }
 
-    /// get_safe_alt_min - returns the minimum safe altitude (i.e. alt_min - margin)
+    /// get_safe_alt_min - returns the minimum safe altitude (i.e. alt_min + margin)
     float get_safe_alt_min() const { return _alt_min + _margin; }
 
     /// get_radius - returns the fence radius in meters
@@ -177,4 +180,6 @@ private:
     bool            _boundary_create_attempted = false; // true if we have attempted to create the boundary array
     bool            _boundary_loaded = false;       // true if boundary array has been loaded from eeprom
     bool            _boundary_valid = false;        // true if boundary forms a closed polygon
+    bool            _low_alt_fence_enabled;
+
 };

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -435,8 +435,9 @@ bool AP_Proximity::get_downward_distance(uint8_t instance, float &distance) cons
 bool AP_Proximity::get_upward_distance(float &distance) const
 {
     for (uint8_t i=0; i<num_instances; i++) {
-        if (get_orientation(i) == ROTATION_PITCH_90) {
-            return get_upward_distance(i, distance);
+        if (get_orientation(i) == PROXIMITY_UP_DOWN) {
+            if (get_upward_distance(i, distance))
+                return true;
         }
     }
     return false;
@@ -446,8 +447,9 @@ bool AP_Proximity::get_upward_distance(float &distance) const
 bool AP_Proximity::get_downward_distance(float &distance) const
 {
     for (uint8_t i=0; i<num_instances; i++) {
-        if (get_orientation(i) == ROTATION_PITCH_270) {
-            return get_downward_distance(i, distance);
+        if (get_orientation(i) == PROXIMITY_UP_DOWN) {
+            if (get_downward_distance(i, distance))
+                return true;
         }
     }
     return false;

--- a/libraries/AP_Proximity/AP_Proximity.cpp
+++ b/libraries/AP_Proximity/AP_Proximity.cpp
@@ -420,7 +420,35 @@ bool AP_Proximity::get_upward_distance(uint8_t instance, float &distance) const
     return drivers[instance]->get_upward_distance(distance);
 }
 
+bool AP_Proximity::get_downward_distance(uint8_t instance, float &distance) const
+{
+    if ((drivers[instance] == nullptr) || (_type[instance] == Proximity_Type_None)) {
+        return false;
+    }
+    // get downward distance from backend
+    return drivers[instance]->get_downward_distance(distance);
+}
+
+
+
+
 bool AP_Proximity::get_upward_distance(float &distance) const
 {
-    return get_upward_distance(primary_instance, distance);
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (get_orientation(i) == ROTATION_PITCH_90) {
+            return get_upward_distance(i, distance);
+        }
+    }
+    return false;
+}
+
+
+bool AP_Proximity::get_downward_distance(float &distance) const
+{
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (get_orientation(i) == ROTATION_PITCH_270) {
+            return get_downward_distance(i, distance);
+        }
+    }
+    return false;
 }

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -122,7 +122,9 @@ public:
 
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(uint8_t instance, float &distance) const;
+    bool get_downward_distance(uint8_t instance, float &distance) const;
     bool get_upward_distance(float &distance) const;
+    bool get_downward_distance(float &distance) const;
 
     // parameter list
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Proximity/AP_Proximity.h
+++ b/libraries/AP_Proximity/AP_Proximity.h
@@ -26,6 +26,7 @@
 #define PROXIMITY_MAX_IGNORE                6   // up to six areas can be ignored
 #define PROXIMITY_MAX_DIRECTION 8
 #define PROXIMITY_SENSOR_ID_START 10
+#define PROXIMITY_UP_DOWN                   1
 
 class AP_Proximity_Backend;
 

--- a/libraries/AP_Proximity/AP_Proximity_Backend.h
+++ b/libraries/AP_Proximity/AP_Proximity_Backend.h
@@ -41,6 +41,8 @@ public:
 
     // get distance upwards in meters. returns true on success
     virtual bool get_upward_distance(float &distance) const { return false; }
+    // get distance downward in meters. returns true on success
+    virtual bool get_downward_distance(float &distance) const { return false; }
 
     // handle mavlink DISTANCE_SENSOR messages
     virtual void handle_msg(mavlink_message_t *msg) {}

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.cpp
@@ -60,7 +60,15 @@ void AP_Proximity_RangeFinder::update(void)
             if (sensor->orientation() == ROTATION_PITCH_90) {
                 _distance_upward = sensor->distance_cm() / 100.0f;
                 _last_upward_update_ms = AP_HAL::millis();
+                _last_update_ms = AP_HAL::millis();
             }
+            // check downward facing range finder
+            if (sensor->orientation() == ROTATION_PITCH_270) {
+                _distance_downward = sensor->distance_cm() / 100.0f;
+                _last_downward_update_ms = AP_HAL::millis();
+                _last_update_ms = AP_HAL::millis();
+            }
+
         }
     }
 
@@ -81,3 +89,14 @@ bool AP_Proximity_RangeFinder::get_upward_distance(float &distance) const
     }
     return false;
 }
+
+// get distance downwards in meters. returns true on success
+bool AP_Proximity_RangeFinder::get_downward_distance(float &distance) const
+{
+    if ((_last_downward_update_ms != 0) && (AP_HAL::millis() - _last_downward_update_ms <= PROXIMITY_RANGEFIDER_TIMEOUT_MS)) {
+        distance = _distance_downward;
+        return true;
+    }
+    return false;
+}
+

--- a/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
+++ b/libraries/AP_Proximity/AP_Proximity_RangeFinder.h
@@ -22,6 +22,10 @@ public:
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(float &distance) const;
 
+    // get distance downward in meters. returns true on success
+    bool get_downward_distance(float &distance) const;
+
+
 private:
 
     // horizontal distance support
@@ -32,4 +36,8 @@ private:
     // upward distance support
     uint32_t _last_upward_update_ms;    // system time of last update distance
     float _distance_upward;             // upward distance in meters
+
+    // downward distance support
+    uint32_t _last_downward_update_ms;    // system time of last update distance
+    float _distance_downward;             // downward distance in meters
 };

--- a/libraries/AP_Proximity/AP_Proximity_SITL.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.cpp
@@ -42,6 +42,10 @@ AP_Proximity_SITL::AP_Proximity_SITL(AP_Proximity &_frontend,
     if (fence_alt_max == nullptr || ptype != AP_PARAM_FLOAT) {
         AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MAX");
     }
+    fence_alt_min = (AP_Float *)AP_Param::find("FENCE_ALT_MIN", &ptype);
+    if (fence_alt_min == nullptr || ptype != AP_PARAM_FLOAT) {
+        AP_HAL::panic("Proximity_SITL: Failed to find FENCE_ALT_MIN");
+    }
 }
 
 // update the state of the sensor
@@ -134,6 +138,13 @@ bool AP_Proximity_SITL::get_upward_distance(float &distance) const
 {
     // return distance to fence altitude
     distance = MAX(0.0f, fence_alt_max->get() - sitl->height_agl);
+    return true;
+}
+
+bool AP_Proximity_SITL::get_downward_distance(float &distance) const
+{
+    // return distance to fence altitude
+    distance = MAX(0.0f, sitl->height_agl - fence_alt_min->get());
     return true;
 }
 

--- a/libraries/AP_Proximity/AP_Proximity_SITL.h
+++ b/libraries/AP_Proximity/AP_Proximity_SITL.h
@@ -22,12 +22,15 @@ public:
 
     // get distance upwards in meters. returns true on success
     bool get_upward_distance(float &distance) const;
+    // get distance downward in meters. returns true on success
+    bool get_downward_distance(float &distance) const;
 
 private:
     SITL::SITL *sitl;
     Vector2l *fence;
     AP_Int8 *fence_count;
     AP_Float *fence_alt_max;
+    AP_Float *fence_alt_min;
     uint32_t last_load_ms;
     AC_PolyFence_loader fence_loader;
     Location current_loc;


### PR DESCRIPTION
Problem: get_orientation return 
0: Default 
1: Upside/Down
And not the actual position of the sensor (ROTATION_PITCH_90 or ROTATION_PITCH_270) so the get_upward/downward_distance functions always return false.

Solution: check if it exists any sensors in position Upside/Down and get the value of the rangefinder. If no upward or downward sensor, it returns false (we suppose there is only one sensor possible in these positions)