### PR TITLE
AP_FETtecOneWire: implement AP_ESC_Telem_Backend

### DIFF
--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -103,15 +103,19 @@ void AP_FETtecOneWire::update()
     }
 
     if (_telem_avail != -1) {
+        const uint32_t now = AP_HAL::millis();
         // TODO: take the _telem_semaphore here
         for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
             _telemetry[i][_telem_avail] = requestedTelemetry[i];
+            if (_telem_avail == telem_type::ERPM) {
+                update_rpm(i, requestedTelemetry[i])
+            }
             _telemetry[i][5]++;
+            _telemetry[i][6] = now;
         }
         // TODO: give back the _telem_semaphore here
 
         AP_Logger *logger = AP_Logger::get_singleton();
-        const uint32_t now = AP_HAL::millis();
         // log at 10Hz
         if (logger && logger->logging_enabled() && now - _last_log_ms > 100) {
             for (uint8_t i = 0; i < MOTOR_COUNT_MAX; i++) {
@@ -169,6 +173,61 @@ void AP_FETtecOneWire::send_esc_telemetry_mavlink(uint8_t mav_chan) const
             }
         }
     }
+}
+
+/// return number of motors present
+uint8_t AP_FETtecOneWire::get_num_motors() const {
+    uint8_t nmotors = 0;
+    uint16_t mask = uint16_t(motor_mask.get());
+    while (mask) {
+        nmotors += mask & 1;
+        mask >>= 1;
+    }
+    return nmotors;
+}
+
+bool AP_FETtecOneWire::get_usage_seconds(uint8_t esc_id, uint32_t& usage_secs) const
+{
+    return false;  // Not implemented by FETtecOneWire protocol
+}
+
+/// get an individual ESC's temperature in degrees if available, returns true on success
+bool AP_FETtecOneWire::get_temperature(uint8_t esc_id, int16_t& temp) const
+{
+    if (esc_id >= MOTOR_COUNT_MAX || _telemetry[esc_id][6] == 0) {
+        return false;
+    }
+    temp = _telemetry[esc_id][telem_type::TEMP];
+    return true;
+}
+
+/// get an individual ESC's rpm if available, returns true on success
+bool AP_FETtecOneWire::get_rpm(uint8_t esc_id, uint16_t& rpm) const
+{
+    if (esc_id >= MOTOR_COUNT_MAX || _telemetry[esc_id][6] == 0) {
+        return false;
+    }
+    rpm = _telemetry[esc_id][telem_type::ERPM];
+    return true;
+}
+
+/// get an individual ESC's current [cA] if available, returns true on success
+bool AP_FETtecOneWire::get_current_ca(uint8_t esc_id, uint16_t& amps_ca) const
+{
+    if (esc_id >= MOTOR_COUNT_MAX || _telemetry[esc_id][6] == 0) {
+        return false;
+    }
+    amps_ca = _telemetry[esc_id][telem_type::CURRENT];
+    return true;
+}
+
+/// return last_update_time_ms if we have received any telemetry data
+uint32_t AP_FETtecOneWire::have_telem_data(uint8_t esc_id) const
+{
+    if (esc_id >= MOTOR_COUNT_MAX) {
+        return 0;
+    }
+	return _telemetry[esc_id][6];
 }
 
 /**

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
 
@@ -30,7 +31,7 @@
 
 
 
-class AP_FETtecOneWire {
+class AP_FETtecOneWire : public AP_ESC_Telem_Backend {
 public:
     AP_FETtecOneWire();
 
@@ -45,6 +46,27 @@ public:
     static AP_FETtecOneWire *get_singleton() {
         return _singleton;
     }
+
+    // AP_ESC_Telem_Backend API
+
+    // number of active ESCs
+    uint8_t get_num_motors(void) const override;
+
+    /// return total usage time in seconds if available, returns true on success
+    bool get_usage_seconds(uint8_t esc_id, uint32_t& usage_sec) const override;
+
+    /// get an individual ESC's temperature in degrees if available, returns true on success
+    bool get_temperature(uint8_t esc_id, int16_t& temp) const override;
+
+    /// get an individual ESC's rpm if available, returns true on success
+    bool get_rpm(uint8_t esc_id, uint16_t& rpm) const override;
+
+    /// get an individual ESC's current in centi-amps if available, returns true on success
+    bool get_current_ca(uint8_t esc_id, uint16_t& amps_ca) const override;
+
+    /// return last_update_time_ms if we have received any telemetry data
+    uint32_t have_telem_data(uint8_t esc_id) const override;
+
 private:
     void init();
     static AP_FETtecOneWire *_singleton;
@@ -57,14 +79,15 @@ private:
     static constexpr uint32_t DELAY_TIME_US = 700;
     static constexpr uint8_t MOTOR_COUNT_MAX = 12; /// OneWire supports up-to 25 ESCs, but Ardupilot only supports 12
     int8_t _telem_avail = -1;
-    /// contains 6 fields per ESC:
+    /// contains 7 fields per ESC:
     ///  - _telemetry[i][0] -> temperature[idx]
     ///  - _telemetry[i][1] -> voltage[idx]
     ///  - _telemetry[i][2] -> current[idx]
     ///  - _telemetry[i][3] -> rpm[idx]
     ///  - _telemetry[i][4] -> totalcurrent[idx]
     ///  - _telemetry[i][5] -> count[idx]
-    uint16_t _telemetry[MOTOR_COUNT_MAX][6] = {0};
+    ///  - _telemetry[i][6] -> last_update_time_ms[idx]
+    uint16_t _telemetry[MOTOR_COUNT_MAX][7] = {0};
     uint16_t _motorpwm[MOTOR_COUNT_MAX] = {1000};
     uint8_t _telem_req_type; /// the requested telemetry type (telem_type::XXXXX)
 


### PR DESCRIPTION
This adds generic ESC telemetry support (for dynamic notch filters)

Requires ArduPilot/ardupilot#16725