### PR TITLE
type responses from uart

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -40,6 +40,7 @@
 #include <AP_RCMapper/AP_RCMapper.h>
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_OSD/AP_OSD.h>
+#include <AP_FETtecOneWire/AP_FETtecOneWire.h>
 
 #if HAL_MAX_CAN_PROTOCOL_DRIVERS
   #include <AP_CANManager/AP_CANManager.h>
@@ -995,6 +996,24 @@ bool AP_Arming::osd_checks(bool display_failure) const
     return true;
 }
 
+bool AP_Arming::fettec_checks(bool display_failure) const
+{
+#if HAL_AP_FETTEC_ONEWIRE_ENABLED
+    const AP_FETtecOneWire *f = AP_FETtecOneWire::get_singleton();
+    if (f == nullptr) {
+        return true;
+    }
+
+    // check camera is ready
+    char fail_msg[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    if (!f->pre_arm_check(fail_msg, ARRAY_SIZE(fail_msg))) {
+        check_failed(ARMING_CHECK_ALL, display_failure, "FETtec: %s", fail_msg);
+        return false;
+    }
+#endif
+    return true;
+}
+
 // request an auxiliary authorisation id.  This id should be used in subsequent calls to set_aux_auth_passed/failed
 // returns true on success
 bool AP_Arming::get_aux_auth_id(uint8_t& auth_id)
@@ -1156,6 +1175,7 @@ bool AP_Arming::pre_arm_checks(bool report)
         &  proximity_checks(report)
         &  camera_checks(report)
         &  osd_checks(report)
+        &  fettec_checks(report)
         &  visodom_checks(report)
         &  aux_auth_checks(report)
         &  disarm_switch_checks(report)

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -180,6 +180,8 @@ protected:
 
     bool can_checks(bool report);
 
+    bool fettec_checks(bool display_failure) const;
+
     virtual bool proximity_checks(bool report) const;
 
     bool servo_checks(bool report) const;

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -741,6 +741,15 @@ void AP_FETtecOneWire::escs_set_values(const uint16_t* motor_values, const int8_
     }
 }
 
+bool AP_FETtecOneWire::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const
+{
+    if (!_initialised) {
+        hal.util->snprintf(failure_msg, failure_msg_len, "Not initialised");
+        return false;
+    }
+    return true;
+}
+
 /// periodically called from SRV_Channels::push()
 void AP_FETtecOneWire::update()
 {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -334,7 +334,6 @@ AP_FETtecOneWire::pull_state AP_FETtecOneWire::pull_command(const T &cmd, R &res
         if (temp_response.esc_id != response.esc_id) {
             // we got a valid packet back - but it wasn't from the correct ESC!
         } else {
-            response = temp_response;
             _scan.rx_try_cnt = 0;
             _scan.trans_try_cnt = 0;
             _pull_busy = false;

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -31,17 +31,17 @@
 
 // Get static info from the ESCs (optional feature)
 #ifndef HAL_AP_FETTEC_ONEWIRE_GET_STATIC_INFO
-#define HAL_AP_FETTEC_ONEWIRE_GET_STATIC_INFO 0
+#define HAL_AP_FETTEC_ONEWIRE_GET_STATIC_INFO 1
 #endif
 
 // provide beep support (optional feature)
 #ifndef HAL_AP_FETTEC_ESC_BEEP
-#define HAL_AP_FETTEC_ESC_BEEP 0
+#define HAL_AP_FETTEC_ESC_BEEP 1
 #endif
 
 // provide light support (optional feature)
 #ifndef HAL_AP_FETTEC_ESC_LIGHT
-#define HAL_AP_FETTEC_ESC_LIGHT 0
+#define HAL_AP_FETTEC_ESC_LIGHT 1
 #endif
 
 #if HAL_AP_FETTEC_ONEWIRE_ENABLED

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -64,6 +64,8 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
+    bool pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) const;
+
     /// periodically called from SRV_Channels::push()
     void update();
     static AP_FETtecOneWire *get_singleton() {

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -49,6 +49,7 @@
 #include <AP_ESC_Telem/AP_ESC_Telem.h>
 #include <AP_Param/AP_Param.h>
 
+#include <AP_Math/AP_Math.h>
 #include <AP_Math/crc.h>
 
 class AP_FETtecOneWire : public AP_ESC_Telem_Backend
@@ -340,6 +341,35 @@ private:
         uint8_t esc_count;
     };
 
+
+#if HAL_AP_FETTEC_ONEWIRE_GET_STATIC_INFO
+    class PACKED ESC_TYPE {
+    public:
+        ESC_TYPE(uint8_t _type) :
+            type{_type} { }
+        uint8_t type;
+    };
+
+    class PACKED SW_VER {
+    public:
+        SW_VER(uint8_t _version, uint8_t _subversion) :
+            version{_version},
+            subversion{_subversion}
+            { }
+        uint8_t version;
+        uint8_t subversion;
+    };
+
+    class PACKED SN {
+    public:
+        SN(uint8_t *_sn, uint8_t snlen) {
+            memset(sn, 0, ARRAY_SIZE(sn));
+            memcpy(sn, _sn, MIN(ARRAY_SIZE(sn), snlen));
+        }
+        uint8_t sn[12];
+    };
+
+#endif
 
     class PACKED START_FW {
     public:


### PR DESCRIPTION
 - eliminates response[] and uses types instead to get responses
 - validates that we've gotten the correct type of response
 - validates that the response came from the ESC we were expecting it from

Costs 150 bytes, but this is an interim step anyway and it gains us a lot of validation


@amilcarlucas I'm not sure why this has multiple commits; I'm guessing you interactively rebased your branch and force-pushed it up.  You'll need to look at the commits separately.
